### PR TITLE
Bugfix - couple_openmc._change_cell_material

### DIFF
--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -554,7 +554,7 @@ class Couple_openmc(object):
 			# 	if bucell_name in self.selected_bucells_nucl_list_dict:
 			# 		if self.selected_bucells_nucl_list_dict[bucell_name] == 'initial nuclides':
 			# 			continue
-			cell = summary.geometry.get_cells_by_name(bucell_name)[0]
+			cell = summary.geometry.get_cells_by_name(bucell_name,matching=True)[0]
 			self._add_zero_dens_nuclides(cell)
 
 


### PR DESCRIPTION
Added matching=True argument to the cell name lookup in _change_cell_material to avoid accidental mixups when cell names are contained in a different cells name (e.g. 'fuel element' and 'fuel element cladding', looking up the first can find the second and lead to problems/a crash later on)